### PR TITLE
Validation

### DIFF
--- a/classes/automodeler.php
+++ b/classes/automodeler.php
@@ -192,7 +192,7 @@ class AutoModeler extends Model implements ArrayAccess
 		foreach ($this->_callbacks as $field => $callback)
 			$data->callback($field, array($this, $callback));
 
-		if ($data->check())
+		if ($data->check(TRUE))
 		{
 			$this->_validation = NULL;
 			return $this->_validated = TRUE;


### PR DESCRIPTION
Allow for models with empty rules. Recently there was a parameter added to the check method of the Validate class which allows the validation to pass when there are no rules.

Fix for Issue #7
