### PR TITLE
Simple query builder fix for the magic set Belongs To insert query.

### DIFF
--- a/classes/automodeler/orm/core.php
+++ b/classes/automodeler/orm/core.php
@@ -74,7 +74,7 @@ class AutoModeler_ORM_Core extends AutoModeler
 			$this_key = inflector::singular($this->_table_name).'_id';
 			$f_key = inflector::singular($related_table).'_id';
 			// See if this is already in the join table
-			if ( ! count(db::select('*')->from($related_table.'_'.$this->_table_name)->where($this_key, '=', $value)->where($f_key, '=', $this->_data['id'])->execute($this->_db)))
+			if ( ! count(db::select('*')->from($related_table.'_'.$this->_table_name)->where($f_key, '=', $value)->where($this_key, '=', $this->_data['id'])->execute($this->_db)))
 			{
 				// Insert
 				db::insert($related_table.'_'.$this->_table_name)->columns(array($f_key, $this_key))->values(array($value, $this->_data['id']))->execute($this->_db);

--- a/classes/automodeler/orm/core.php
+++ b/classes/automodeler/orm/core.php
@@ -77,7 +77,7 @@ class AutoModeler_ORM_Core extends AutoModeler
 			if ( ! count(db::select('*')->from($related_table.'_'.$this->_table_name)->where($this_key, '=', $value)->where($f_key, '=', $this->_data['id'])->execute($this->_db)))
 			{
 				// Insert
-				db::insert($related_table.'_'.$this->_table_name, array($f_key => $value, $this_key => $this->_data['id']))->execute($this->_db);
+				db::insert($related_table.'_'.$this->_table_name)->columns(array($f_key, $this_key))->values(array($value, $this->_data['id']))->execute($this->_db);
 			}
 		}
 		elseif (strpos($key, ':')) // Process with

--- a/classes/automodeler/orm/core.php
+++ b/classes/automodeler/orm/core.php
@@ -346,7 +346,9 @@ class AutoModeler_ORM_Core extends AutoModeler
 	 */
 	public function remove($key, $id)
 	{
-		return db::delete($this->_table_name.'_'.AutoModeler::factory(inflector::singular($key))->get_table_name())->where($key.'_id', '=', $id)->where(inflector::singular($this->_table_name).'_id', '=', $this->_data['id'])->execute($this->_db);
+		$related = AutoModeler::factory(inflector::singular($key));
+		
+		return db::delete($this->_table_name.'_'.$related->get_table_name())->where(inflector::singular($related->get_table_name()).'_id', '=', $id)->where(inflector::singular($this->_table_name).'_id', '=', $this->_data['id'])->execute($this->_db);
 	}
 
 	/**

--- a/tests/test_automodeler_orm.php
+++ b/tests/test_automodeler_orm.php
@@ -388,4 +388,58 @@ class AutoModeler_ORM_Test extends PHPUnit_Extensions_Database_TestCase
 
 			$this->assertSame($model->username, 'foobar');
 		}
+		
+	public function provider_set_has_many()
+	{
+		return array(
+			array('Model_ORMUser', 3, 'testroles', 2),
+			array('Model_ORMUser', 2, 'testroles', 1),
+		);
+	}
+
+	/**
+	 * Tests creating Many to Many relationships with __set().
+	 *
+	 * @dataProvider provider_set_has_many
+	 *
+	 * @covers AutoModeler_ORM::__set
+	 * @author Jonathan Davis
+	 */
+	public function test_set_has_many($model_name, $model_id, $related_model, $related_id)
+	{
+		$model = new $model_name($model_id);
+
+		// Remove relationship if it alread exists.
+		$model->remove($related_model, $related_id);
+
+		$model->{$related_model} = $related_id;
+
+		$this->assertTrue($model->has($related_model, $related_id));
+	}
+
+	public function provider_set_belongs_to()
+	{
+		return array(
+			array('Model_TestRole', 1, 'ormusers', 3),
+			array('Model_TestRole', 2, 'ormusers', 2),
+		);
+	}
+
+	/**
+	 * Tests creating Belongs To relationships with __set().
+	 *
+	 * @dataProvider provider_set_belongs_to
+	 *
+	 * @covers AutoModeler_ORM::__set
+	 * @author Jonathan Davis
+	 */
+	public function test_set_belongs_to($model_name, $model_id, $parent_model, $parent_id)
+	{
+		$model = new $model_name($model_id);
+		$model->remove_parent($parent_model);
+
+		$model->{$parent_model} = $parent_id;
+
+		$this->assertSame(1, count($model->find_parent($parent_model)));
+	}
 }


### PR DESCRIPTION
Magic set Belongs To insert query now correctly sets the column names and insert values, see Issue #42.
